### PR TITLE
Prevent overwriting of FlxStudio.instance

### DIFF
--- a/flixel/addons/studio/FlxStudio.hx
+++ b/flixel/addons/studio/FlxStudio.hx
@@ -65,7 +65,8 @@ class FlxStudio extends flixel.system.debug.Window
 	// TODO: choose a good name for this
 	public static function start():Void
 	{
-		FlxStudio.instance = new FlxStudio();
+		if (FlxStudio.instance == null)
+			FlxStudio.instance = new FlxStudio();
 	}
 
 	/**


### PR DESCRIPTION
Allows repeated switches to the state that contains
FlxStudio.start() call. See #12.