### PR TITLE
rename start to create, allow it to be called any time

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,7 @@ Usually libs are listed in the libraries section of the `Project.xml` file, whic
 
 ### 3. Usage (code)
 
-After installing and adding `flixel-studio` to your project, you are ready to start using it.
-
-Open any class that describes a state of your game, e.g. `PlayState`. In the `create()` method, add the following line (no matter the place):
-
-```haxe
-flixel.addons.studio.FlxStudio.start();
-```
-
-Your `create()` method will end up looking like this:
+After installing and adding `flixel-studio` to your project, you are ready to start using it. To add the FlxStudio windows to the FlxDebugger, call `flixel.addons.studio.FlxStudio.create()` anytime after the FlxGame is created, , e.g. in your Document class or in your FlxState's create override.
 
 ```haxe
 override public function create():Void
@@ -81,22 +73,23 @@ override public function create():Void
 }
 ```
 
-Alterantively, you can import `FlxStudio` and then invoke `FlxStudio.start()`:
+Alterantively, you can import `FlxStudio` and then invoke `FlxStudio.create()`:
 
 ```haxe
+package;
 
-import flixel.FlxState;
+import flixel.FlxGame;
 import flixel.addons.studio.FlxStudio;
+import openfl.display.Sprite;
 
-class PlayState extends FlxState
+class Main extends Sprite
 {
-	override public function create():Void
+	public function new():Void
 	{
-		super.create();
-
-		// [your own code here]
-
-		FlxStudio.start();
+		super();
+		
+		addChild(new FlxGame(0, 0, MyInitialState));	
+		FlxStudio.create();
 	}
 }
 ```

--- a/flixel/addons/studio/FlxStudio.hx
+++ b/flixel/addons/studio/FlxStudio.hx
@@ -63,23 +63,29 @@ class FlxStudio extends flixel.system.debug.Window
 	public var itemAddedToLibrary:FlxTypedSignal<LibraryItem->Void> = new FlxTypedSignal();	
 
 	// TODO: choose a good name for this
-	public static function start():Void
+	public static function create():Void
 	{
-		FlxStudio.instance = new FlxStudio();
+		if (instance == null)
+			new FlxStudio();
 	}
 
 	/**
 	 * TODO: add docs
 	 */
-	public function new()
+	function new()
 	{
 		super("FlxStudio");
 		visible = false;
-
+		
+		FlxStudio.instance = this;
+		
 		// Initialize everything only after the game has been started, that way
 		// we have access to all element added during the game's `create()` call.
 		// It allows developers to call `FlxStudio.start()` at any point.
-		FlxG.signals.postGameStart.addOnce(bootstrap);
+		if (FlxG.game != null && FlxG.game.debugger != null)
+			bootstrap();
+		else
+			FlxG.signals.postGameStart.addOnce(bootstrap);
 	}
 
 	/**
@@ -93,7 +99,7 @@ class FlxStudio extends flixel.system.debug.Window
 
 		addInteractionTools();
 		initSignals();
-		initUI();		
+		initUI();
 
 		FlxG.game.debugger.addWindow(this);
 		setExitHandler(onExit);

--- a/flixel/addons/studio/FlxStudio.hx
+++ b/flixel/addons/studio/FlxStudio.hx
@@ -76,7 +76,6 @@ class FlxStudio extends flixel.system.debug.Window
 	{
 		super("FlxStudio");
 		visible = false;
-		
 		FlxStudio.instance = this;
 		
 		// Initialize everything only after the game has been started, that way


### PR DESCRIPTION
 it seems as though we can call bootstrap once the `FlxG.game.debugger` is created. additionally, we can't create a new Library instance before `FlxStudio.instance` is set, so I'm setting the instance in the constructor

notes:

- the FlxStudio constructor is now private
- I included the changes from #16, to prevent merge conflicts

See #12 