### PR TITLE
Update outdated method name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ override public function create():Void
 
 	// [your own code here]
 
-	flixel.addons.studio.FlxStudio.start();
+	flixel.addons.studio.FlxStudio.create();
 }
 ```
 


### PR DESCRIPTION
Seems like this was an oversight in #17.